### PR TITLE
Use a custom error type instead of String for errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@ use resvg::usvg::{NodeExt, TreeWriting, XmlOptions};
 /// See below for an example:
 ///
 /// ```rust
-/// use unsvg::{Image, COLORS};
+/// use unsvg::{Image, COLORS, Error};
 ///
-/// fn main() -> Result<(), String> {
+/// fn main() -> Result<(), Error> {
 ///     let mut img: Image = Image::new(200, 200);
 ///     let second_point = img.draw_simple_line(10.0, 10.0, 120, 100.0, COLORS[1])?;
 ///     let third_point = img.draw_simple_line(second_point.0, second_point.1, 240, 100.0, COLORS[2])?;


### PR DESCRIPTION
Currently, fallible functions in `unsvg` will return `Result<T, String>`. But certain things people might want to do (e.g. use the `anyhow` crate to do error handling) don't play well with this because `String` doesn't implement `std::error::Error`. This PR introduces a small custom `Error` type which does, but ultimately just wraps around the `String`s from before. There's also a `Result` type alias to go along with it, in the spirit of things like [Result in `std::io`](https://doc.rust-lang.org/stable/std/io/type.Result.html).

(Bonus: `cargo fmt` has now been run on the code, since my editor does that automatically on save.)