### PR TITLE
Added ColorIndex and basic implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,17 @@ pub enum ColorIndex {
     Grey,
 }
 
-impl Into<usize> for ColorIndex {
-    fn into(self) -> usize {
-        match self {
+impl From<ColorIndex> for Color {
+    fn from(index: ColorIndex) -> Self {
+        COLORS[Into::<usize>::into(index)]
+    }
+}
+
+impl From<ColorIndex> for usize {
+    /// Converts a `ColorIndex` to a usize.
+    /// This usize value corresponds with the index of the color in the COLORS array.
+    fn from(index: ColorIndex) -> Self {
+        match index {
             ColorIndex::Black => 0,
             ColorIndex::Blue => 1,
             ColorIndex::Cyan => 2,
@@ -185,58 +193,73 @@ impl Into<usize> for ColorIndex {
     }
 }
 
-impl From<usize> for ColorIndex {
-    fn from(index: usize) -> Self {
+impl TryFrom<usize> for ColorIndex {
+    type Error = Error;
+
+    /// Tries to convert from color to a `ColorIndex` variant.
+    /// Errors when the the provided index is too large for the COLORS array (index > 15).
+    fn try_from(index: usize) -> Result<Self> {
         match index {
-            0 => ColorIndex::Black,
-            1 => ColorIndex::Blue,
-            2 => ColorIndex::Cyan,
-            3 => ColorIndex::Green,
-            4 => ColorIndex::Red,
-            5 => ColorIndex::Magenta,
-            6 => ColorIndex::Yellow,
-            7 => ColorIndex::White,
-            8 => ColorIndex::Brown,
-            9 => ColorIndex::Tan,
-            10 => ColorIndex::Forest,
-            11 => ColorIndex::Aqua,
-            12 => ColorIndex::Salmon,
-            13 => ColorIndex::Purple,
-            14 => ColorIndex::Orange,
-            15 => ColorIndex::Grey,
-            _ => ColorIndex::Black,
+            0 => Ok(ColorIndex::Black),
+            1 => Ok(ColorIndex::Blue),
+            2 => Ok(ColorIndex::Cyan),
+            3 => Ok(ColorIndex::Green),
+            4 => Ok(ColorIndex::Red),
+            5 => Ok(ColorIndex::Magenta),
+            6 => Ok(ColorIndex::Yellow),
+            7 => Ok(ColorIndex::White),
+            8 => Ok(ColorIndex::Brown),
+            9 => Ok(ColorIndex::Tan),
+            10 => Ok(ColorIndex::Forest),
+            11 => Ok(ColorIndex::Aqua),
+            12 => Ok(ColorIndex::Salmon),
+            13 => Ok(ColorIndex::Purple),
+            14 => Ok(ColorIndex::Orange),
+            15 => Ok(ColorIndex::Grey),
+            _ => Err(Error("Invalid color index".to_string())),
         }
     }
 }
 
-impl From<u32> for ColorIndex {
-    fn from(index: u32) -> Self {
+impl TryFrom<u64> for ColorIndex {
+    type Error = Error;
+
+    /// Tries to convert from color to a `ColorIndex` variant.
+    /// Errors when the the provided index is too large for the COLORS array (index > 15).
+    fn try_from(index: u64) -> Result<Self> {
         match index {
-            0 => ColorIndex::Black,
-            1 => ColorIndex::Blue,
-            2 => ColorIndex::Cyan,
-            3 => ColorIndex::Green,
-            4 => ColorIndex::Red,
-            5 => ColorIndex::Magenta,
-            6 => ColorIndex::Yellow,
-            7 => ColorIndex::White,
-            8 => ColorIndex::Brown,
-            9 => ColorIndex::Tan,
-            10 => ColorIndex::Forest,
-            11 => ColorIndex::Aqua,
-            12 => ColorIndex::Salmon,
-            13 => ColorIndex::Purple,
-            14 => ColorIndex::Orange,
-            15 => ColorIndex::Grey,
-            _ => ColorIndex::Black,
+            0 => Ok(ColorIndex::Black),
+            1 => Ok(ColorIndex::Blue),
+            2 => Ok(ColorIndex::Cyan),
+            3 => Ok(ColorIndex::Green),
+            4 => Ok(ColorIndex::Red),
+            5 => Ok(ColorIndex::Magenta),
+            6 => Ok(ColorIndex::Yellow),
+            7 => Ok(ColorIndex::White),
+            8 => Ok(ColorIndex::Brown),
+            9 => Ok(ColorIndex::Tan),
+            10 => Ok(ColorIndex::Forest),
+            11 => Ok(ColorIndex::Aqua),
+            12 => Ok(ColorIndex::Salmon),
+            13 => Ok(ColorIndex::Purple),
+            14 => Ok(ColorIndex::Orange),
+            15 => Ok(ColorIndex::Grey),
+            _ => Err(Error("Invalid color index".to_string())),
         }
     }
 }
 
-impl ColorIndex {
-    /// Get the color as a `Color` struct.
-    pub fn get_color(&self) -> Color {
-        COLORS[Into::<usize>::into(*self)]
+impl TryFrom<Color> for ColorIndex {
+    type Error = Error;
+
+    /// Tries to convert from a `Color` to a `ColorIndex` variant.
+    /// Errors when the the provided Color is not in the COLORS array.
+    fn try_from(color: Color) -> Result<Self> {
+        COLORS
+            .iter()
+            .position(|&c| c == color)
+            .ok_or(Error("Color not in COLORS array".to_string()))
+            .and_then(|i| ColorIndex::try_from(i))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,106 @@ pub static COLORS: [Color; 16] = [
     },
 ];
 
+/// Enum of the 16 colors available in the original Logo language.
+/// Implements `Into<usize>` to convert the enum to a usize, for indexing into the COLORS array.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ColorIndex {
+    Black,
+    Blue,
+    Cyan,
+    Green,
+    Red,
+    Magenta,
+    Yellow,
+    White,
+    Brown,
+    Tan,
+    Forest,
+    Aqua,
+    Salmon,
+    Purple,
+    Orange,
+    Grey,
+}
+
+impl Into<usize> for ColorIndex {
+    fn into(self) -> usize {
+        match self {
+            ColorIndex::Black => 0,
+            ColorIndex::Blue => 1,
+            ColorIndex::Cyan => 2,
+            ColorIndex::Green => 3,
+            ColorIndex::Red => 4,
+            ColorIndex::Magenta => 5,
+            ColorIndex::Yellow => 6,
+            ColorIndex::White => 7,
+            ColorIndex::Brown => 8,
+            ColorIndex::Tan => 9,
+            ColorIndex::Forest => 10,
+            ColorIndex::Aqua => 11,
+            ColorIndex::Salmon => 12,
+            ColorIndex::Purple => 13,
+            ColorIndex::Orange => 14,
+            ColorIndex::Grey => 15,
+        }
+    }
+}
+
+impl From<usize> for ColorIndex {
+    fn from(index: usize) -> Self {
+        match index {
+            0 => ColorIndex::Black,
+            1 => ColorIndex::Blue,
+            2 => ColorIndex::Cyan,
+            3 => ColorIndex::Green,
+            4 => ColorIndex::Red,
+            5 => ColorIndex::Magenta,
+            6 => ColorIndex::Yellow,
+            7 => ColorIndex::White,
+            8 => ColorIndex::Brown,
+            9 => ColorIndex::Tan,
+            10 => ColorIndex::Forest,
+            11 => ColorIndex::Aqua,
+            12 => ColorIndex::Salmon,
+            13 => ColorIndex::Purple,
+            14 => ColorIndex::Orange,
+            15 => ColorIndex::Grey,
+            _ => ColorIndex::Black,
+        }
+    }
+}
+
+impl From<u32> for ColorIndex {
+    fn from(index: u32) -> Self {
+        match index {
+            0 => ColorIndex::Black,
+            1 => ColorIndex::Blue,
+            2 => ColorIndex::Cyan,
+            3 => ColorIndex::Green,
+            4 => ColorIndex::Red,
+            5 => ColorIndex::Magenta,
+            6 => ColorIndex::Yellow,
+            7 => ColorIndex::White,
+            8 => ColorIndex::Brown,
+            9 => ColorIndex::Tan,
+            10 => ColorIndex::Forest,
+            11 => ColorIndex::Aqua,
+            12 => ColorIndex::Salmon,
+            13 => ColorIndex::Purple,
+            14 => ColorIndex::Orange,
+            15 => ColorIndex::Grey,
+            _ => ColorIndex::Black,
+        }
+    }
+}
+
+impl ColorIndex {
+    /// Get the color as a `Color` struct.
+    pub fn get_color(&self) -> Color {
+        COLORS[Into::<usize>::into(*self)]
+    }
+}
+
 /// Tells you where a line will end, given a starting point, direction, and length.
 /// This is used by `draw_simple_line` to get the end point of a line.
 pub fn get_end_coordinates(x: f32, y: f32, direction: i32, length: f32) -> (f32, f32) {


### PR DESCRIPTION
Added a public `ColorIndex` enum that has implementations for multiple traits to allow for easy conversions between colors and usize. The following are implemented:

- `From<ColorIndex> for Color`
- `From<ColorIndex> for usize`
- `TryFrom<usize> for ColorIndex`
- `TryFrom<u64> for ColorIndex`
- `TryFrom<Color> for ColorIndex`

I believe this enum and the implementations are extremely useful for unsvg users as it maintains backwards compatibility while providing a self documenting interface that is easier to work with. 

Please let me know if there is any issue :)

Resolves #6 