### PR TITLE
Documentation Fixes/Tweaks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,22 +41,24 @@ type Result<T> = core::result::Result<T, Error>;
 /// This contains 16 simple colors which users can select from.
 /// These correspond to the 16 colors available in the original Logo language.
 /// The colors are:
-///  - Black
-///  - Blue
-///  - Cyan
-///  - Green
-///  - Red
-///  - Magenta
-///  - Yellow
-///  - White
-///  - Brown
-///  - Tan
-///  - Forest
-///  - Aqua
-///  - Salmon
-///  - Purple
-///  - Orange
-///  - Grey
+/// ```
+///   0: Black
+///   1: Blue
+///   2: Cyan
+///   3: Green
+///   4: Red
+///   5: Magenta
+///   6: Yellow
+///   7: White
+///   8: Brown
+///   9: Tan
+///  10: Forest
+///  11: Aqua
+///  12: Salmon
+///  13: Purple
+///  14: Orange
+///  15: Grey
+/// ```
 pub static COLORS: [Color; 16] = [
     Color {
         red: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,22 @@
+//! The unsvg crate provides a very simple interface for drawing images.
+//!
+//! See below for an example:
+//!
+//! ```rust
+//! use unsvg::{Image, COLORS, Error};
+//!
+//! fn main() -> Result<(), Error> {
+//!     let mut img: Image = Image::new(200, 200);
+//!     let second_point = img.draw_simple_line(10.0, 10.0, 120, 100.0, COLORS[1])?;
+//!     let third_point = img.draw_simple_line(second_point.0, second_point.1, 240, 100.0, COLORS[2])?;
+//!     let _ = img.draw_simple_line(third_point.0, third_point.1, 0, 100.0, COLORS[3])?;
+//!
+//!     img.save_svg("path_to.svg")?;
+//!
+//!     Ok(())
+//! }
+//! ```
 use resvg::usvg::{NodeExt, TreeWriting, XmlOptions};
-/// The unsvg crate provides a very simple interface for drawing images.
-///
-/// See below for an example:
-///
-/// ```rust
-/// use unsvg::{Image, COLORS, Error};
-///
-/// fn main() -> Result<(), Error> {
-///     let mut img: Image = Image::new(200, 200);
-///     let second_point = img.draw_simple_line(10.0, 10.0, 120, 100.0, COLORS[1])?;
-///     let third_point = img.draw_simple_line(second_point.0, second_point.1, 240, 100.0, COLORS[2])?;
-///     let _ = img.draw_simple_line(third_point.0, third_point.1, 0, 100.0, COLORS[3])?;
-///
-///     img.save_svg("path_to.svg")?;
-///
-///     Ok(())
-/// }
-/// ```
 use resvg::{tiny_skia, usvg};
 use std::rc::Rc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,10 @@ impl Image {
         (self.width, self.height)
     }
 
-    /// Save the image to a file.
+    /// Save the image to a file in the `png` format.
+    /// 
+    /// Rasterises the image and stores it as a grid of pixels.
+    /// Use this if you want an image that is easy to display/view.
     ///
     /// ```rs
     /// let image = Image::new(100, 100);
@@ -225,7 +228,10 @@ impl Image {
         pixmap.save_png(path).map_err(|e| Error(e.to_string()))
     }
 
-    /// Save the image to a file.
+    /// Save the image to a file in the `svg` format.
+    ///
+    /// Stores the image in a lossless vector image format.
+    /// Use this if the precision of your lines is important.
     ///
     /// ```rs
     /// let image = Image::new(100, 100);


### PR DESCRIPTION
This pull request fixes a documentation error and proposes two tweaks to the documentation.

The top-level crate documentation is fixed to properly use `//!` instead of `///`, meaning that it will properly appear on the home page of the html documentation. (Resolves #4.)

The documentation for the `COLORS` array has been modified to include array indices in the list of colours, so that a user doesn't have to count the dot points to determine, for example, that `white` is index 7.

The documentation for the `save_png` and `save_svg` functions are expanded to include reasons why a user might choose to use one over the other.